### PR TITLE
removed echo from getBaseAccessTokenUrl()

### DIFF
--- a/src/Bynder/Api/Impl/OAuth2/BynderOauthProvider.php
+++ b/src/Bynder/Api/Impl/OAuth2/BynderOauthProvider.php
@@ -50,7 +50,6 @@ class BynderOauthProvider extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        echo $this->bynderDomain;
         return $this->bynderDomain . '/v6/authentication/oauth2/token';
     }
 


### PR DESCRIPTION
There's possibly an unwanted echo in getBaseAccessTokenUrl(). This PR removes it.