### PR TITLE
Allow to change the oauth state and use a random string instead

### DIFF
--- a/src/Bynder/Api/BynderClient.php
+++ b/src/Bynder/Api/BynderClient.php
@@ -48,7 +48,7 @@ class BynderClient
     public function getAuthorizationUrl(array $scope, $state = null)
     {
         return $this->requestHandler->getAuthorizationUrl([
-            'state' => $state ? $state : sha1(uniqid()),
+            'state' => $state,
             'scope' => implode(' ', $scope)
         ]);
     }

--- a/src/Bynder/Api/BynderClient.php
+++ b/src/Bynder/Api/BynderClient.php
@@ -41,6 +41,7 @@ class BynderClient
      * Returns the Oauth authorization url for user login.
      *
      * @param array $scope Custom scopes can be passed to override the defaults
+     * @param string $state Custom state can be passed to override the default random generation
      *
      * @return string
      */

--- a/src/Bynder/Api/BynderClient.php
+++ b/src/Bynder/Api/BynderClient.php
@@ -44,10 +44,10 @@ class BynderClient
      *
      * @return string
      */
-    public function getAuthorizationUrl(array $scope)
+    public function getAuthorizationUrl(array $scope, string $state = null)
     {
         return $this->requestHandler->getAuthorizationUrl([
-            'state' => sprintf('domain=%s', $this->configuration->getBynderDomain()),
+            'state' => $state ?? sha1(uniqid()),
             'scope' => implode(' ', $scope)
         ]);
     }

--- a/src/Bynder/Api/BynderClient.php
+++ b/src/Bynder/Api/BynderClient.php
@@ -44,10 +44,10 @@ class BynderClient
      *
      * @return string
      */
-    public function getAuthorizationUrl(array $scope, string $state = null)
+    public function getAuthorizationUrl(array $scope, $state = null)
     {
         return $this->requestHandler->getAuthorizationUrl([
-            'state' => $state ?? sha1(uniqid()),
+            'state' => $state ? $state : sha1(uniqid()),
             'scope' => implode(' ', $scope)
         ]);
     }


### PR DESCRIPTION
Allow to change the oauth state and use a random string instead for security purposes

> A random string used to maintain state between the request and callback. This value must is used to prevent CSRF attacks.

https://bynder.docs.apiary.io/#reference/oauth-2.0/authorization-endpoint/authorize-application