### PR TITLE
Add getMetapropertyOptionsById function

### DIFF
--- a/src/Bynder/Api/Impl/AssetBankManager.php
+++ b/src/Bynder/Api/Impl/AssetBankManager.php
@@ -120,13 +120,14 @@ class AssetBankManager
     /**
      * Gets a list of metaproperty options.
      *
+     * @param  string  $propertyId  Metaproperty id
      * @param  array  $query  Associative array of parameters to filter the results.
      * @return \GuzzleHttp\Promise\Promise
      * @throws \GuzzleHttp\Exception\RequestException
      */
-    public function getMetapropertyOptions($query)
+    public function getMetapropertyOptions($propertyId, $query)
     {
-        return $this->requestHandler->sendRequestAsync('GET', 'api/v4/metaproperties/options/',
+        return $this->requestHandler->sendRequestAsync('GET', 'api/v4/metaproperties/' . $propertyId . '/options/',
             ['query' => $query]
         );
     }

--- a/src/Bynder/Api/Impl/AssetBankManager.php
+++ b/src/Bynder/Api/Impl/AssetBankManager.php
@@ -120,12 +120,26 @@ class AssetBankManager
     /**
      * Gets a list of metaproperty options.
      *
+     * @param  array  $query  Associative array of parameters to filter the results.
+     * @return \GuzzleHttp\Promise\Promise
+     * @throws \GuzzleHttp\Exception\RequestException
+     */
+    public function getMetapropertyOptions($query)
+    {
+        return $this->requestHandler->sendRequestAsync('GET', 'api/v4/metaproperties/options/',
+            ['query' => $query]
+        );
+    }
+
+    /**
+     * Gets a list of metaproperty options.
+     *
      * @param  string  $propertyId  Metaproperty id
      * @param  array  $query  Associative array of parameters to filter the results.
      * @return \GuzzleHttp\Promise\Promise
      * @throws \GuzzleHttp\Exception\RequestException
      */
-    public function getMetapropertyOptions($propertyId, $query)
+    public function getMetapropertyOptionsById($propertyId, $query)
     {
         return $this->requestHandler->sendRequestAsync('GET', 'api/v4/metaproperties/' . $propertyId . '/options/',
             ['query' => $query]

--- a/tests/AssetBank/AssetBankManagerTest.php
+++ b/tests/AssetBank/AssetBankManagerTest.php
@@ -464,6 +464,35 @@ class AssetBankManagerTest extends TestCase
     }
 
     /**
+     * Test if we call getMetapropertyOptionsById it will use the correct params for the request and returns successfully.
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::getMetapropertyOptionsById()
+     * @throws \Exception
+     */
+    public function testGetMetapropertyOptionsById()
+    {
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $propertyId = '00000000-0000-0000-0000000000000000';
+        $optionId = '00000000-0000-0000-0000000000000001';
+        $query = ['ids' => $optionId];
+
+        $stub->method('sendRequestAsync')
+            ->with('GET', 'api/v4/metaproperties/' . $propertyId . '/options/', [
+                    'query' => $query
+            ])
+            ->willReturn(['query']);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $result = $assetBankManager->getMetapropertyOptionsById($query);
+
+        self::assertNotNull($result);
+        self::assertEquals($result, ['query']);
+    }
+
+    /**
      * Test if we call getMetapropetryGlobalOptionDependencies it will use the correct params for the request and
      * returns successfully.
      *

--- a/tests/AssetBank/AssetBankManagerTest.php
+++ b/tests/AssetBank/AssetBankManagerTest.php
@@ -486,7 +486,7 @@ class AssetBankManagerTest extends TestCase
             ->willReturn(['query']);
 
         $assetBankManager = new AssetBankManager($stub);
-        $result = $assetBankManager->getMetapropertyOptionsById($query);
+        $result = $assetBankManager->getMetapropertyOptionsById($propertyId, $query);
 
         self::assertNotNull($result);
         self::assertEquals($result, ['query']);


### PR DESCRIPTION
There is a small error in `AssetBankManager`

According to [the documentation](https://bynder.docs.apiary.io/#reference/metaproperties/metaproperty-option-operations/retrieve-metaproperty-options), we should use the propertyID in the URL when retrieving option for a specific meta property.

This PR simply add the parameter and use it to fix it.