### PR TITLE
Enable original filename parameter

### DIFF
--- a/src/Bynder/Api/Impl/Upload/FileUploader.php
+++ b/src/Bynder/Api/Impl/Upload/FileUploader.php
@@ -126,8 +126,8 @@ class FileUploader
                 }
             )
             ->then(
-                function ($value) {
-                    return $this->finalizeUploadAsync($value['requestInfo'], $value['chunkNumber']);
+                function ($value) use ($data) {
+                    return $this->finalizeUploadAsync($value['requestInfo'], $value['chunkNumber'], $data);
                 }
             )
             ->then(
@@ -265,11 +265,12 @@ class FileUploader
      *
      * @param $uploadRequestInfo
      * @param $chunkNumber
+     * @param array $originalData
      *
      * @return Promise\Promise
      * @throws Exception
      */
-    private function finalizeUploadAsync($uploadRequestInfo, $chunkNumber)
+    private function finalizeUploadAsync($uploadRequestInfo, $chunkNumber, $originalData)
     {
         $s3Filename = sprintf("%s/p%d", $uploadRequestInfo['s3_filename'], $chunkNumber);
 
@@ -279,6 +280,11 @@ class FileUploader
             's3_filename' => $s3Filename,
             'chunks' => $chunkNumber,
         ];
+
+        if (isset($originalData['original_filename']) && $originalData['original_filename']) {
+            $data['original_filename'] = $originalData['original_filename'];
+        }
+
         return $this->requestHandler->sendRequestAsync(
             'POST',
             'api/v4/upload/',


### PR DESCRIPTION
According to [the documentation](https://bynder.docs.apiary.io/#reference/upload-assets/4-finalise-a-completely-uploaded-file/finalise-a-completely-uploaded-file), an `original_filename` could be used when uploading a file.  
Without it, the full path of the file is used and then shown to the end user, which is not great.

This PR simply enable the parameter to be used when saving the uploaded file as documented.