### PR TITLE
Fixed namespace of Exception in AbstractRequestHandler

### DIFF
--- a/src/Bynder/Api/Impl/AbstractRequestHandler.php
+++ b/src/Bynder/Api/Impl/AbstractRequestHandler.php
@@ -12,7 +12,7 @@ abstract class AbstractRequestHandler
         );
 
         if (!in_array($requestMethod, ['GET', 'POST', 'DELETE'])) {
-            throw new Exception('Invalid request method provided');
+            throw new \Exception('Invalid request method provided');
         }
 
         $request = $this->sendAuthenticatedRequest($requestMethod, $uri, $options);
@@ -28,7 +28,7 @@ abstract class AbstractRequestHandler
                     case 'text/html':
                         return $response;
                     default:
-                        throw new Exception('The response type not recognized.');
+                        throw new \Exception('The response type not recognized.');
                 }
             }
         );


### PR DESCRIPTION
```
Error: Class "Bynder\Api\Impl\Exception" not found in _Bynder\Api\Impl\AbstractRequestHandler->Bynder\Api\Impl
{closure}() (line _31 of /var/www/html/vendor/bynder/bynder-php-sdk/src/Bynder/Api/Impl/AbstractRequestHandler.php).
```