### PR TITLE
Do not throw exceptions on API 204 No Content responses without a Content-Type header

### DIFF
--- a/src/Bynder/Api/Impl/AbstractRequestHandler.php
+++ b/src/Bynder/Api/Impl/AbstractRequestHandler.php
@@ -27,6 +27,9 @@ abstract class AbstractRequestHandler
                         return (string)$response->getBody();
                     case 'text/html':
                         return $response;
+                    // 204 No Content responses have no content type header.
+                    case $response->getStatusCode() == 204:
+                        return $response;
                     default:
                         throw new Exception('The response type not recognized.');
                 }


### PR DESCRIPTION
The response from https://bynder.docs.apiary.io/#reference/asset-usage/asset-usage-operations/delete-asset-usage is a HTTP 204 code with no Content-Type header at all provided in the response. This causes an exception to be thrown when using the PHP SDK.