### PR TITLE
Fixed 204 API responses with no content type still fail

### DIFF
--- a/src/Bynder/Api/Impl/AbstractRequestHandler.php
+++ b/src/Bynder/Api/Impl/AbstractRequestHandler.php
@@ -19,6 +19,10 @@ abstract class AbstractRequestHandler
 
         return $request->then(
             function ($response) {
+                // Some 204 No Content responses have no content type header.
+                if ($response->getStatusCode() === 204 && !$response->hasHeader('Content-Type')) {
+                  return NULL;
+                }
                 $mimeType = explode(';', $response->getHeader('Content-Type')[0])[0];
                 switch($mimeType) {
                     case 'application/json':
@@ -26,9 +30,6 @@ abstract class AbstractRequestHandler
                     case 'text/plain':
                         return (string)$response->getBody();
                     case 'text/html':
-                        return $response;
-                    // 204 No Content responses have no content type header.
-                    case $response->getStatusCode() == 204:
                         return $response;
                     default:
                         throw new \Exception('The response type not recognized.');


### PR DESCRIPTION
Using a switch wasn't the right fix here, it needs to be a separate if check before we start looking at content-type header. I have tested this locally.