### PR TITLE
Fix the error: "deprecated function: creation of dynamic property ..."

### DIFF
--- a/src/Bynder/Api/Impl/PermanentTokens/Configuration.php
+++ b/src/Bynder/Api/Impl/PermanentTokens/Configuration.php
@@ -9,6 +9,7 @@
 
 namespace Bynder\Api\Impl\PermanentTokens;
 
+#[AllowDynamicProperties]
 class Configuration
 {
     private $bynderDomain;


### PR DESCRIPTION
Trying to fix the error on PHP 8.2.x:

`deprecated function: creation of dynamic property bynder\api\impl\permanenttokens\configuration::$requestoptions is deprecated in bynder\api\impl\permanenttokens\configuration->__construct()`