### PR TITLE
Add getUsers and getProfiles functions

### DIFF
--- a/src/Bynder/Api/Impl/AssetBankManager.php
+++ b/src/Bynder/Api/Impl/AssetBankManager.php
@@ -35,6 +35,31 @@ class AssetBankManager
     }
 
     /**
+     * Gets a list of all users, params sent in $query will filter the results.
+     *
+     * @param  array  $query
+     * @return \GuzzleHttp\Promise\Promise with a list of Users.
+     * @throws \GuzzleHttp\Exception\RequestException When request fails.
+     */
+    public function getUsers($query = null)
+    {
+        return $this->requestHandler->sendRequestAsync('GET', 'api/v4/users/',
+            ['query' => $query]
+        );
+    }
+
+    /**
+     * Gets a list of all available security profiles.
+     *
+     * @return \GuzzleHttp\Promise\Promise with a list of all Profiles.
+     * @throws \GuzzleHttp\Exception\RequestException When request fails.
+     */
+    public function getProfiles()
+    {
+        return $this->requestHandler->sendRequestAsync('GET', 'api/v4/profiles/');
+    }
+
+    /**
      * Gets a list of all available brands.
      *
      * @return \GuzzleHttp\Promise\Promise with a list of all Brands.

--- a/tests/AssetBank/AssetBankManagerTest.php
+++ b/tests/AssetBank/AssetBankManagerTest.php
@@ -9,6 +9,62 @@ class AssetBankManagerTest extends TestCase
 {
 
     /**
+     * Test if we call getUsers it will use the correct params for the request and returns successfully.
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::getUsers()
+     * @throws \Exception
+     */
+    public function testGetUsers()
+    {
+        $returnedBrands = [];
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $query = [
+            'includeInActive' => true,
+            'limit' => 50,
+            'page' => 2
+        ];
+
+        $stub->expects($this->once())
+            ->method('sendRequestAsync')
+            ->with('GET', 'api/v4/users/', ['query' => $query])
+            ->willReturn([]);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $brands = $assetBankManager->getUsers($query);
+
+        self::assertNotNull($brands);
+        self::assertEquals($brands, $returnedBrands);
+    }
+
+    /**
+     * Test if we call getProfiles it will use the correct params for the request and returns successfully.
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::getProfiles()
+     * @throws \Exception
+     */
+    public function testGetProfiles()
+    {
+        $returnedBrands = [];
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->expects($this->once())
+            ->method('sendRequestAsync')
+            ->with('GET', 'api/v4/profiles/')
+            ->willReturn([]);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $brands = $assetBankManager->getProfiles();
+
+        self::assertNotNull($brands);
+        self::assertEquals($brands, $returnedBrands);
+    }
+
+    /**
      * Test if we call getBrands it will use the correct params for the request and returns successfully.
      *
      * @covers \Bynder\Api\Impl\AssetBankManager::getBrands()


### PR DESCRIPTION
This PR add 2 functions corresponding to existing API:
- [getUsers](https://bynder.docs.apiary.io/#reference/users/user-operations/retrieve-users) 
- [getProfiles](https://bynder.docs.apiary.io/#reference/security-roles/security-profile-operations/retrieve-security-profiles)