### PR TITLE
Fix form_params usage in Permanent token sendAuthenticatedRequest

### DIFF
--- a/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
+++ b/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
@@ -19,7 +19,18 @@ class RequestHandler extends AbstractRequestHandler
 
     protected function sendAuthenticatedRequest($requestMethod, $uri, $options = [])
     {
+        $formParams = false;
+        if (isset($options['form_params'])) {
+            $formParams = $options['form_params'];
+            unset($options['form_params']);
+        }
+
         $request = new \GuzzleHttp\Psr7\Request($requestMethod, $uri, $options);
+
+        if ($formParams) {
+            $options['form_params'] = $formParams;
+        }
+
         return $this->httpClient->sendAsync(
             $request,
             array_merge(


### PR DESCRIPTION
Using a Permanent Token,
When trying to modify description of a media with multiple lines like that:  
```php
$description = 'Line 1
Line 2';
$client->getAssetBankManager()->modifyMedia($mediaId, [
    'description' => $description,
])->wait();
```

I had the Guzzle error:
```
[InvalidArgumentException]                                              
"Line 1                                                 
Line 2" is not valid header value.
```

The reason is simple:  
The form_params is sent to headers when creating Requests...

The fix simply remove the setting from the header and everything is working correctly for me.