### PR TITLE
Implement 4 missing API endpoints

### DIFF
--- a/src/Bynder/Api/Impl/AssetBankManager.php
+++ b/src/Bynder/Api/Impl/AssetBankManager.php
@@ -60,6 +60,17 @@ class AssetBankManager
     }
 
     /**
+     * Gets account information
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws \Exception
+     */
+    public function getAccount()
+    {
+        return $this->requestHandler->sendRequestAsync('GET', "api/v4/account/");
+    }
+
+    /**
      * Gets a list of all available brands.
      *
      * @return \GuzzleHttp\Promise\Promise with a list of all Brands.
@@ -168,6 +179,42 @@ class AssetBankManager
     {
         return $this->requestHandler->sendRequestAsync('GET', 'api/v4/metaproperties/' . $propertyId . '/options/',
             ['query' => $query]
+        );
+    }
+
+    /**
+     * Creates an option for a metaproperty.
+     *
+     * @param string $metaPropId
+     * @param array $data
+     * @return \GuzzleHttp\Promise\Promise
+     * @throws \Exception
+     */
+    public function createMetaPropertyOption($metaPropId, $data)
+    {
+        return $this->requestHandler->sendRequestAsync(
+            'POST',
+            sprintf('api/v4/metaproperties/%s/options/', $metaPropId),
+            ['form_params' => ['data' => json_encode($data)]]
+        );
+    }
+
+    /**
+     * Modifies existing metaproperty option.
+     *
+     * @param string $metaPropId
+     * @param string $optionId
+     * @param array  $data
+     *
+     * @return \GuzzleHttp\Promise\Promise
+     * @throws \Exception
+     */
+    public function modifyMetaPropertyOption($metaPropId, $optionId, $data)
+    {
+        return $this->requestHandler->sendRequestAsync(
+            'POST',
+            sprintf('api/v4/metaproperties/%s/options/%s/', $metaPropId, $optionId),
+            ['form_params' => ['data' => json_encode($data)]]
         );
     }
 
@@ -386,12 +433,27 @@ class AssetBankManager
      *
      * @param  $query
      * @return \GuzzleHttp\Promise\Promise
-     * @throws \GuzzleHttp\Exception\RequestException 
+     * @throws \GuzzleHttp\Exception\RequestException
      */
     public function deleteUsage($query)
     {
         return $this->requestHandler->sendRequestAsync('DELETE', 'api/media/usage',
             ['query' => $query]
+        );
+    }
+
+    /**
+     * Synchronizes asset usages
+     *
+     * @param array $data
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function syncAssetUsage($data)
+    {
+        return $this->requestHandler->sendRequestAsync('POST', 'api/media/usage/sync',
+            ['json' => $data]
         );
     }
 

--- a/tests/AssetBank/AssetBankManagerTest.php
+++ b/tests/AssetBank/AssetBankManagerTest.php
@@ -65,6 +65,48 @@ class AssetBankManagerTest extends TestCase
     }
 
     /**
+     * Test if we call getAccount it will use the correct params for the request and returns successfully.
+     *
+     * @group  collections
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::getCollections()
+     * @throws \Exception
+     */
+    public function testGetAccount()
+    {
+        $returnedAccount = [
+            "availableLanguages" => [
+                "nl_NL",
+                "en_GB",
+                "en_US",
+                "fr_FR",
+                "de_DE",
+                "it_IT",
+                "es_ES",
+                "pl_PL",
+            ],
+            "defaultLanguage"    => "en_US",
+            "name"               => "Bynder",
+            "timeZone"           => "Europe/Amsterdam",
+            "isOpenImageBank"    => false,
+        ];
+
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->method('sendRequestAsync')
+            ->with('GET', "api/v4/account/")
+            ->willReturn($returnedAccount);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $account          = $assetBankManager->getAccount();
+
+        self::assertNotNull($account);
+        self::assertEquals($account, $returnedAccount);
+    }
+
+    /**
      * Test if we call getBrands it will use the correct params for the request and returns successfully.
      *
      * @covers \Bynder\Api\Impl\AssetBankManager::getBrands()
@@ -549,6 +591,72 @@ class AssetBankManagerTest extends TestCase
     }
 
     /**
+     * Tests the createMetaPropertyOption function.
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::createMetaPropertyOption()
+     * @throws \Exception
+     */
+    public function testCreateMetaPropertyOption()
+    {
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $queryData = [
+            'name'              => 'TEST_NAME',
+            'externalReference' => 'TEST_EXTERNAL_REFERENCE',
+            'label'             => 'TEST_EXTERNAL_LABEL',
+        ];
+
+        $stub->method('sendRequestAsync')
+            ->with('POST', 'api/v4/metaproperties/TEST_METAPROPERTY_ID/options/', [
+                'form_params' => ['data' => json_encode($queryData)],
+            ])
+            ->willReturn([]);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $result           = $assetBankManager->createMetaPropertyOption('TEST_METAPROPERTY_ID', $queryData);
+
+        self::assertNotNull($result);
+        self::assertEquals($result, []);
+    }
+
+    /**
+     * Tests the modifyMetaPropertyOption function.
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::createMetaPropertyOption()
+     * @throws \Exception
+     */
+    public function testModifyMetaPropertyOption()
+    {
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $queryData = [
+            'name'              => 'TEST_NAME',
+            'externalReference' => 'TEST_EXTERNAL_REFERENCE',
+            'label'             => 'TEST_EXTERNAL_LABEL',
+        ];
+
+        $stub->method('sendRequestAsync')
+            ->with('POST', 'api/v4/metaproperties/TEST_METAPROPERTY_ID/options/TEST_OPTION_ID/', [
+                'form_params' => ['data' => json_encode($queryData)],
+            ])
+            ->willReturn([]);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $result           = $assetBankManager->modifyMetaPropertyOption(
+            'TEST_METAPROPERTY_ID',
+            'TEST_OPTION_ID',
+            $queryData
+        );
+
+        self::assertNotNull($result);
+        self::assertEquals($result, []);
+    }
+
+    /**
      * Test if we call getMetapropetryGlobalOptionDependencies it will use the correct params for the request and
      * returns successfully.
      *
@@ -718,6 +826,50 @@ class AssetBankManagerTest extends TestCase
 
         self::assertNotNull($result);
         self::assertEquals($result, array());
+    }
+
+    /**
+     * Tests the syncAssetUsage function.
+     *
+     * @covers \Bynder\Api\Impl\AssetBankManager::deleteUsage()
+     * @throws \Exception
+     */
+    public function testSyncAssetUsage()
+    {
+        $stub = $this->getMockBuilder('Bynder\Api\Impl\OAuth2\RequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $queryData = [
+            'integration_id' => 'TEST_INTEGRATION_ID',
+            'uris'           => ['TEST_URI_1', 'TEST_URI_2', 'TEST_URI_TO_DELETE_1'],
+            'usages'         => [
+                'integration_id' => 'TEST_INTEGRATION_ID',
+                'asset_id'       => 'TEST_ASSET_ID_1',
+                'timestamp'      => (new \Datetime())->format('Y-m-d\TH:i:s\Z'),
+                'additional'     => 'TEST_ADDITIONAL_DATA_1',
+                'uri'            => 'TEST_URI_1',
+            ],
+            [
+                'integration_id' => 'TEST_INTEGRATION_ID',
+                'asset_id'       => 'TEST_ASSET_ID_2',
+                'timestamp'      => (new \Datetime())->format('Y-m-d\TH:i:s\Z'),
+                'additional'     => 'TEST_ADDITIONAL_DATA_2',
+                'uri'            => 'TEST_URI_2',
+            ],
+        ];
+
+        $stub->method('sendRequestAsync')
+            ->with('POST', 'api/media/usage/sync', [
+                'json' => $queryData,
+            ])
+            ->willReturn([]);
+
+        $assetBankManager = new AssetBankManager($stub);
+        $result           = $assetBankManager->syncAssetUsage($queryData);
+
+        self::assertNotNull($result);
+        self::assertEquals($result, []);
     }
 
     /**


### PR DESCRIPTION
Create 5 new function to use missing endpoints 
- createMetaPropertyOption 
- modifyMetaPropertyOption
- getSingleMetaPropertyOptions
- syncAssetUsage
- getAccount

Update Request handler to fix an issue with json requests (Sync asset usage)