### PR TITLE
Fix Outh2 refresh token

### DIFF
--- a/src/Bynder/Api/Impl/OAuth2/Configuration.php
+++ b/src/Bynder/Api/Impl/OAuth2/Configuration.php
@@ -10,6 +10,7 @@
 namespace Bynder\Api\Impl\OAuth2;
 
 use Bynder\Api\Impl\Oauth2\BynderOauthProvider;
+use League\OAuth2\Client\Token\AccessToken;
 
 /**
  * Class to hold Oauth2 tokens necessary for every API request.
@@ -122,11 +123,18 @@ class Configuration
             return;
         }
 
-        $this->setToken(
-            $oauthProvider->getAccessToken('refresh_token', [
-                'refresh_token' => $this->getToken()->getRefreshToken()
-            ])
-        );
+        $oldRefreshToken =  $this->getToken()->getRefreshToken();
+
+        $token = $oauthProvider->getAccessToken('refresh_token', [
+            'refresh_token' => $oldRefreshToken
+        ]);
+
+        $options = $token->jsonSerialize();
+        if (empty($options['refresh_token'])) {
+            $options['refresh_token'] = $oldRefreshToken;
+        }
+
+        $this->setToken(new AccessToken($options));
     }
 
     public function getRequestOptions()


### PR DESCRIPTION
As per the [API documentation](https://bynder.docs.apiary.io/#reference/oauth-2.0/token-endpoint/using-a-refresh-token), the API does not return return the refresh_token. 

So we have to keep the previous token's `refresh_token` to make sure it is available for further refresh requests. 

Fix Issue https://github.com/Bynder/bynder-php-sdk/issues/29 