### PR TITLE
Allow setting a custom User-Agent

### DIFF
--- a/src/Bynder/Api/Impl/OAuth2/RequestHandler.php
+++ b/src/Bynder/Api/Impl/OAuth2/RequestHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bynder\Api\Impl\OAuth2;
 
 use Bynder\Api\Impl\AbstractRequestHandler;
@@ -18,7 +19,7 @@ class RequestHandler extends AbstractRequestHandler
             'clientId' => $configuration->getClientId(),
             'clientSecret' => $configuration->getClientSecret(),
             'redirectUri' => $configuration->getRedirectUri(),
-            'bynderDomain' => $configuration->getBynderDomain()
+            'bynderDomain' => $configuration->getBynderDomain(),
         ]);
     }
 
@@ -46,18 +47,20 @@ class RequestHandler extends AbstractRequestHandler
     {
         $this->configuration->refreshToken($this->oauthProvider);
 
+        $requestOptions = array_merge(
+            $options,
+            $this->configuration->getRequestOptions()
+        );
+
+        if (!isset($requestOptions['headers']['User-Agent'])) {
+            $requestOptions['headers']['User-Agent'] = 'bynder-php-sdk/' . $this->configuration->getSdkVersion();
+        }
+
         return $this->oauthProvider->getHttpClient()->sendAsync(
             $this->oauthProvider->getAuthenticatedRequest(
                 $requestMethod, $uri, $this->configuration->getToken()
             ),
-            array_merge(
-                $options,
-                $this->configuration->getRequestOptions(),
-                ['headers'=> [
-                        'User-Agent' => 'bynder-php-sdk/' . $this->configuration->getSdkVersion()
-                    ]
-                ]
-            )
+            $requestOptions
         );
     }
 }

--- a/src/Bynder/Api/Impl/OAuth2/RequestHandler.php
+++ b/src/Bynder/Api/Impl/OAuth2/RequestHandler.php
@@ -52,7 +52,7 @@ class RequestHandler extends AbstractRequestHandler
             $this->configuration->getRequestOptions()
         );
 
-        if (!isset($requestOptions['headers']['User-Agent'])) {
+        if (!isset($requestOptions['headers']) || !isset($requestOptions['headers']['User-Agent'])) {
             $requestOptions['headers']['User-Agent'] = 'bynder-php-sdk/' . $this->configuration->getSdkVersion();
         }
 

--- a/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
+++ b/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
@@ -31,16 +31,20 @@ class RequestHandler extends AbstractRequestHandler
             $options['form_params'] = $formParams;
         }
 
-        return $this->httpClient->sendAsync(
-            $request,
-            array_merge(
-                $options,
-                $this->configuration->getRequestOptions(),
-                ['headers'=> [
-                    'User-Agent' => 'bynder-php-sdk/' . $this->configuration->getSdkVersion(),
-                    'Authorization' => 'Bearer ' . $this->configuration->getToken()
-                ]]
-            )
+        $requestOptions = array_merge(
+            $options,
+            $this->configuration->getRequestOptions(),
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->configuration->getToken(),
+                ],
+            ]
         );
+
+        if (!isset($requestOptions['headers']['User-Agent'])) {
+            $requestOptions['headers']['User-Agent'] = 'bynder-php-sdk/' . $this->configuration->getSdkVersion();
+        }
+
+        return $this->httpClient->sendAsync($request, $requestOptions);
     }
 }


### PR DESCRIPTION
The SDK previously set a default User-Agent, overriding any value provided by the user.

This behavior has now changed: if no User-Agent is specified, the SDK will set a default one.
If a custom User-Agent is provided, it will be preserved.