### PR TITLE
Fix `json` in Permanent token sendAuthenticatedRequest

### DIFF
--- a/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
+++ b/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
@@ -19,17 +19,13 @@ class RequestHandler extends AbstractRequestHandler
 
     protected function sendAuthenticatedRequest($requestMethod, $uri, $options = [])
     {
-        $formParams = false;
-        if (isset($options['form_params'])) {
-            $formParams = $options['form_params'];
-            unset($options['form_params']);
-        }
-
-        $request = new \GuzzleHttp\Psr7\Request($requestMethod, $uri, $options);
-
-        if ($formParams) {
-            $options['form_params'] = $formParams;
-        }
+        $request = new \GuzzleHttp\Psr7\Request($requestMethod, $uri, array_filter(
+            $options,
+            function ($key) {
+                return !in_array($key, ['form_params', 'json']);
+            },
+            ARRAY_FILTER_USE_KEY
+        ));
 
         return $this->httpClient->sendAsync(
             $request,


### PR DESCRIPTION
Guzzle throwing errors when sending`json` data with pernanant token request handler: 

`Header value must be scalar or null but array provided.`

This makes function `\Bynder\Api\Impl\AssetBankManager::syncAssetUsage` unusable with permanent tokens

Same issue fixed in #65 but here for json parameter. 


