### PR TITLE
Fix header error for permanentToken

### DIFF
--- a/src/Bynder/Api/Impl/AbstractRequestHandler.php
+++ b/src/Bynder/Api/Impl/AbstractRequestHandler.php
@@ -38,5 +38,19 @@ abstract class AbstractRequestHandler
         );
     }
 
+    protected function getRequestOptions($options = [])
+    {
+        $requestOptions = array_merge(
+            $options,
+            $this->configuration->getRequestOptions()
+        );
+
+        if (!isset($requestOptions['headers']) || !isset($requestOptions['headers']['User-Agent'])) {
+            $requestOptions['headers']['User-Agent'] = 'bynder-php-sdk/' . $this->configuration->getSdkVersion();
+        }
+
+        return $requestOptions;
+    }
+
     abstract protected function sendAuthenticatedRequest($requestMethod, $uri, $options = []);
 }

--- a/src/Bynder/Api/Impl/OAuth2/RequestHandler.php
+++ b/src/Bynder/Api/Impl/OAuth2/RequestHandler.php
@@ -7,8 +7,6 @@ use Bynder\Api\Impl\OAuth2\BynderOauthProvider;
 
 class RequestHandler extends AbstractRequestHandler
 {
-    protected $configuration;
-
     private $oauthProvider;
 
     public function __construct($configuration)
@@ -47,20 +45,11 @@ class RequestHandler extends AbstractRequestHandler
     {
         $this->configuration->refreshToken($this->oauthProvider);
 
-        $requestOptions = array_merge(
-            $options,
-            $this->configuration->getRequestOptions()
-        );
-
-        if (!isset($requestOptions['headers']) || !isset($requestOptions['headers']['User-Agent'])) {
-            $requestOptions['headers']['User-Agent'] = 'bynder-php-sdk/' . $this->configuration->getSdkVersion();
-        }
-
         return $this->oauthProvider->getHttpClient()->sendAsync(
             $this->oauthProvider->getAuthenticatedRequest(
                 $requestMethod, $uri, $this->configuration->getToken()
             ),
-            $requestOptions
+            $this->getRequestOptions($options)
         );
     }
 }

--- a/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
+++ b/src/Bynder/Api/Impl/PermanentTokens/RequestHandler.php
@@ -8,7 +8,6 @@ use Bynder\Api\Impl\AbstractRequestHandler;
 
 class RequestHandler extends AbstractRequestHandler
 {
-    protected $configuration;
     protected $httpClient;
 
     public function __construct($configuration)
@@ -19,32 +18,10 @@ class RequestHandler extends AbstractRequestHandler
 
     protected function sendAuthenticatedRequest($requestMethod, $uri, $options = [])
     {
-        $formParams = false;
-        if (isset($options['form_params'])) {
-            $formParams = $options['form_params'];
-            unset($options['form_params']);
-        }
+        $request = new \GuzzleHttp\Psr7\Request($requestMethod, $uri, [
+            'Authorization' => 'Bearer ' . $this->configuration->getToken(),
+        ]);
 
-        $request = new \GuzzleHttp\Psr7\Request($requestMethod, $uri, $options);
-
-        if ($formParams) {
-            $options['form_params'] = $formParams;
-        }
-
-        $requestOptions = array_merge(
-            $options,
-            $this->configuration->getRequestOptions(),
-            [
-                'headers' => [
-                    'Authorization' => 'Bearer ' . $this->configuration->getToken(),
-                ],
-            ]
-        );
-
-        if (!isset($requestOptions['headers']['User-Agent'])) {
-            $requestOptions['headers']['User-Agent'] = 'bynder-php-sdk/' . $this->configuration->getSdkVersion();
-        }
-
-        return $this->httpClient->sendAsync($request, $requestOptions);
+        return $this->httpClient->sendAsync($request, $this->getRequestOptions($options));
     }
 }


### PR DESCRIPTION
This PR is following #65 to be more versatile and work in any cases.
The `$options` array passed to the `sendAuthenticatedRequest` should not be used as request options.
Instead I changed the way authorization header was set to be more like the OAuth2 implementation.

This PR also standardize how `requestOptions` (and user-agent header) is set to be the same across the 2 implementations.

This PR should be used instead of #82 